### PR TITLE
Cabal sections are case insensitive, fix syntax highlighting

### DIFF
--- a/syntax/cabal.vim
+++ b/syntax/cabal.vim
@@ -18,7 +18,7 @@ syn keyword cabalBool True False
 syn keyword cabalConditional if else
 syn match cabalCompilerFlag "\s\+-[^ -][^ ]*"
 syn match cabalBulletPoint "^\s\+\*"
-syn match cabalSection "^\([eE]xecutable\|[lL]ibrary\|[fF]lag\|[sS]ource-repository\|[tT]est-suite\)"
+syn match cabalSection "^\c\(executable\|library\|flag\|source-repository\|test-suite\)"
 syn match cabalEntry "^\s\{0,4}[A-Za-z][a-zA-Z\-]*:" contains=cabalIdentifier,cabalColon
 
 syn region cabalDescription start="^\s\{0,4}[dD]escription:" end="^\s\{0,4}[A-Za-z][a-zA-Z\-]*:" contains=cabalEntry,cabalLineComment,cabalBulletPoint keepend


### PR DESCRIPTION
For example, this is perfectly fine for Cabal: `TeSt-SuItE ...`.