### PR TITLE
Removes redundant `filetype` .vimrc setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ Be sure that the following lines are in your
 
 
     syntax on
-    filetype on
     filetype plugin indent on
 
 ### Manual Installation


### PR DESCRIPTION
This is a tiny little documentation update. The initial `filetype on` instruction is redundant as the second `filetype` call includes the `on` setting.

Here's the output from `:help filetype-overview` showing that:

```vim
Overview:                                       :filetype-overview       
                                                                         
command                         detection       plugin          indent   
:filetype on                    on              unchanged       unchanged
:filetype off                   off             unchanged       unchanged
:filetype plugin on             on              on              unchanged
:filetype plugin off            unchanged       off             unchanged
:filetype indent on             on              unchanged       on       
:filetype indent off            unchanged       unchanged       off      
:filetype plugin indent on      on              on              on       
:filetype plugin indent off     unchanged       off             off      
```

Thanks for putting this plugin together!