### PR TITLE
Add indentation reset (dumb) on double-<Return>

### DIFF
--- a/indent/haskell.vim
+++ b/indent/haskell.vim
@@ -63,6 +63,10 @@ function! GetHaskellIndent()
     return match(l:prevline, '\S')
   endif
 
+  if l:prevline =~ '^\s*$'
+      return 0
+  endif
+
   let l:line = getline(v:lnum)
 
   if l:line =~ '\C^\s*\<where\>'


### PR DESCRIPTION
With the default Haskell ftplugin, after I hit <Return> twice it undoes whatever indent I might've had in `where` or `let` clauses or branches. I modified haskell-vim to do the same thing, in a dumb way -- right now it just returns the indent to column 0, but it maybe should be smarter about it. I'm not sure how that would be implemented.